### PR TITLE
hide debug info when debug is turned on and then turned off

### DIFF
--- a/src/core/CardContainer.gd
+++ b/src/core/CardContainer.gd
@@ -59,6 +59,8 @@ func _process(_delta: float) -> void:
 		$Debug/Position.text = "POSITION:  " + str(position)
 		$Debug/AreaPos.text = "AREA POS: " + str($CollisionShape2D.position)
 		$Debug/Size.text = "SIZE: " + str($Control.rect_size)
+	else:
+		$Debug.visible = false
 
 
 # Called when the node enters the scene tree for the first time.

--- a/src/core/CardTemplate.gd
+++ b/src/core/CardTemplate.gd
@@ -333,6 +333,8 @@ func _process(delta) -> void:
 		$Debug/state.text = "STATE: " + stateslist[state]
 		$Debug/index.text = "INDEX: " + str(get_index())
 		$Debug/parent.text = "PARENT: " + str(get_parent().name)
+	else:
+		$Debug.visible = false
 
 
 # Triggers the focus-in effect on the card


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/5288733/118777738-f85a6180-b8bb-11eb-9d83-5af90fe6d4b3.gif)

After:
![after](https://user-images.githubusercontent.com/5288733/118777714-f1cbea00-b8bb-11eb-83ac-f8017d226965.gif)

PS:
we can go with `$Debug.visible = ! cfc._debug` but I think it's easier to read this way.
