### PR TITLE
Multiple attach modes added to card template

### DIFF
--- a/src/core/Card/CardFront.gd
+++ b/src/core/Card/CardFront.gd
@@ -189,7 +189,7 @@ func set_rich_label_text(node: RichTextLabel, value: String, is_resize := false,
 		var bbcode_height = node.get_content_height()
 		while bbcode_height == 0 or bbcode_height > 1000:
 			_retries += 1
-			print_debug("BBcode height:" + bbcode_height + " retrying: " + _retries)
+			print_debug("BBcode height:{0} retrying: {1}".format([bbcode_height, _retries]))
 			yield(get_tree(), "idle_frame")
 			bbcode_height = node.get_content_height()
 			if _retries >= 10:

--- a/src/core/CardTemplate.gd
+++ b/src/core/CardTemplate.gd
@@ -45,6 +45,11 @@ enum BoardPlacement{
 	ANY_GRID
 	ANYWHERE
 }
+enum AttachmentMode{
+	DO_NOT_ATTACH	
+	ATTACH_BEHIND
+	ATTACH_IN_FRONT
+}
 enum AttachmentOffset{
 	TOP_LEFT
 	TOP
@@ -108,7 +113,7 @@ export var scripts : Dictionary
 # If true, the card can be attached to other cards and will follow
 # their host around the table. The card will always return to its host
 # when dragged away
-export var is_attachment := false setget set_is_attachment, get_is_attachment
+export(AttachmentMode) var attachment_mode = AttachmentMode.DO_NOT_ATTACH
 # If true, staggers the attachment so the side is also visible
 export(AttachmentOffset) var attachment_offset = AttachmentOffset.TOP
 # If true, the card front will be displayed when mouse hovers over the card
@@ -484,6 +489,9 @@ func _on_Card_gui_input(event) -> void:
 					# to always draw above other objects
 					# We need to reset it to the default of 0
 					z_index = 0
+					for attachment in self.attachments:
+						attachment.z_index = 0
+										
 					var destination = cfc.NMAP.board
 					if potential_container:
 						destination = potential_container
@@ -790,15 +798,6 @@ func set_card_size(value: Vector2, ignore_area = false) -> void:
 		$CollisionShape2D.shape.extents = value / 2
 		$CollisionShape2D.position = value / 2
 
-
-# Setter for _is_attachment
-func set_is_attachment(value: bool) -> void:
-	is_attachment = value
-
-
-# Getter for _is_attachment
-func get_is_attachment() -> bool:
-	return is_attachment
 
 # Setter for is_faceup
 #
@@ -1846,18 +1845,16 @@ func _organize_attachments() -> void:
 			# We use the index of the attachment among other attachments
 			# to figure out its index and placement
 			var attach_index = attachments.find(card)
-			if attach_index:
-				# if the card is not the first attachment to this host
-				# Then we make sure that each subsequent card is higher
-				# in the node hierarchy than its parent
-				# This will make latter cards draw below the others
-				if card.get_index() > attachments[attach_index - 1].get_index():
-					get_parent().move_child(card,
-							attachments[attach_index - 1].get_index())
-			# If the card if the first for its host, we need to make sure
-			# it is higher in the hierarchy than the host
-			elif card.get_index() > self.get_index():
-				get_parent().move_child(card,self.get_index())
+
+			# offset the attachment's position in the boards hierarchy
+			# by the attachment offset
+			if (card.attachment_mode == AttachmentMode.ATTACH_BEHIND and 
+				card.get_index() > (self.get_index()-attach_index)):
+				get_parent().move_child(card, self.get_index()-attach_index)
+			elif(card.attachment_mode == AttachmentMode.ATTACH_IN_FRONT and 
+				card.get_index() < (self.get_index()+attach_index)):
+				get_parent().move_child(card, self.get_index()+attach_index)
+
 			# We don't want to try and move it if it's still tweening.
 			# But if it isn't, we make sure it always follows its parent
 			if not card.get_node('Tween').is_active() and \
@@ -1917,8 +1914,10 @@ func _pushAside(targetpos: Vector2, target_rotation: float) -> void:
 # Pick up a card to drag around with the mouse.
 func _start_dragging(drag_offset: Vector2) -> void:
 	_drag_offset = drag_offset
-	# When dragging we want the dragged card to always be drawn above all else
+	# When dragging we want the dragged card and attachments to always be drawn above all else
 	z_index = 99
+	for attachment in self.attachments:
+		attachment.z_index = 99
 	# We have use parent viewport to calculate global_position
 	# due to godotengine/godot#30215
 	# This is caused because we're using a viewport node and scaling the game
@@ -2363,6 +2362,12 @@ func _process_card_state() -> void:
 		CardState.ON_PLAY_BOARD:
 			# Used when the card is idle on the board
 			z_index = 0
+			
+			# if this card is an attachment and it's host is being dragged 
+			# then we want this card to be above everything like the host
+			if current_host_card and current_host_card.state == CardState.DRAGGED:
+				z_index = 99
+												
 			set_focus(false)
 			set_control_mouse_filters(true)
 			buttons.set_active(false)

--- a/src/core/MousePointer.gd
+++ b/src/core/MousePointer.gd
@@ -158,7 +158,7 @@ func _discover_focus() -> void:
 			# and the checked area has to be on the board
 			if current_focused_card \
 					and current_focused_card == cfc.card_drag_ongoing \
-					and current_focused_card.is_attachment \
+					and (current_focused_card.attachment_mode != Card.AttachmentMode.DO_NOT_ATTACH) \
 					and area != current_focused_card \
 					and not area in current_focused_card.attachments \
 					and area.state == Card.CardState.ON_PLAY_BOARD:
@@ -261,8 +261,8 @@ func _is_placement_slot_valid(slot: BoardPlacementSlot, potential_cards := []) -
 			is_valid = false
 		# We only hihglight a slot if the dragged card is not an attachment
 		# with a potential host highlighted.
-		if cfc.card_drag_ongoing.is_attachment \
-				and not potential_cards.empty():
+		if cfc.card_drag_ongoing.attachment_mode != Card.AttachmentMode.DO_NOT_ATTACH \
+			and not potential_cards.empty():
 			# The card being dragged is usually part of the potential_cards
 			# So we want to make sure we still highlight a potential slot
 			# if it's only the dragged card in there.

--- a/src/custom/CGFBoard.gd
+++ b/src/custom/CGFBoard.gd
@@ -70,7 +70,10 @@ func _on_ScalingFocusOptions_item_selected(index) -> void:
 # Button to make all cards act as attachments
 func _on_EnableAttach_toggled(button_pressed: bool) -> void:
 	for c in get_tree().get_nodes_in_group("cards"):
-		c.is_attachment = button_pressed
+		if button_pressed:
+			c.attachment_mode = Card.AttachmentMode.ATTACH_BEHIND
+		else:
+			c.attachment_mode = Card.AttachmentMode.DO_NOT_ATTACH
 
 
 func _on_Debug_toggled(button_pressed: bool) -> void:

--- a/tests/UTcommon.gd
+++ b/tests/UTcommon.gd
@@ -69,8 +69,8 @@ func draw_test_cards(count: int, fast := true) -> Array:
 		c.reorganize_self()
 	return cards
 
-func click_card(card: Card, use_fake_mouse := true) -> void:
-	var fc:= fake_click(true, Vector2(0,0))
+func click_card(card: Card, use_fake_mouse := true, offset:=Vector2(0,0)) -> void:
+	var fc:= fake_click(true, offset)
 	card._on_Card_gui_input(fc)
 
 func unclick_card(card: Card) -> void:

--- a/tests/integration/test_mouse_pointer.gd
+++ b/tests/integration/test_mouse_pointer.gd
@@ -17,7 +17,7 @@ func before_each():
 func test_highlight_priority():
 	var card : Card = cards[0]
 	yield(table_move(cards[2], Vector2(550,500)), 'completed')
-	card.is_attachment = true
+	card.attachment_mode = Card.AttachmentMode.ATTACH_BEHIND
 	yield(drag_card(card, Vector2(600,500)), 'completed')
 	assert_null(grid.get_highlighted_slot(),
 		"No slot highlighted when potential host highlighted")

--- a/tests/integration/test_scripting_engine_tasks_execute_scripts.gd
+++ b/tests/integration/test_scripting_engine_tasks_execute_scripts.gd
@@ -106,6 +106,7 @@ func test_execute_scripts_with_temp_mod_property():
 	assert_eq(hand.get_card_count(), 7,
 		"Ensure the property does not go negative")
 	target.execute_scripts()
+	yield(yield_for(0.1), YIELD)
 	assert_eq(hand.get_card_count(), 8,
 		"Ensure temp property modifiers don't remain")
 
@@ -147,6 +148,7 @@ func test_execute_scripts_with_temp_mod_counter():
 	assert_eq(hand.get_card_count(), 7,
 		"Ensure the counter does not go negative")
 	target.execute_scripts()
+	yield(yield_for(0.1), YIELD)
 	assert_eq(hand.get_card_count(), 8,
 		"Ensure temp property modifiers don't remain")
 


### PR DESCRIPTION
These changes modify the card template to have a new attachment_mode exported variable in place of the is_attachment boolean flag that was there previously. This allows you to choose how cards attach to host when they are on the board (attach in front or behind).

I've also added unit tests to check attachment indexes relative to their parents for both attachment modes when on board and when dragging the host card around the board.