### PR TITLE
Update QUICKSTART.md

### DIFF
--- a/tutorial/QUICKSTART.md
+++ b/tutorial/QUICKSTART.md
@@ -132,6 +132,7 @@ For this demonstration, let's create a "creature" type card.
 ```
 func _ready() -> void:
 	card_labels["Health"] = find_node("Health")
+	original_font_sizes["Health"] = 16
 ```
 We have now mapped the new label node for our new card type, so that it can be found by our code.
 


### PR DESCRIPTION
Everything in card_labels needs an entry in `original_font_sizes` or else an error occurs. `CGFCardFront.gd` does this for all labels it defines, but if you extend it and add more in `_ready` then that runs after its definition so you need to specify the font size yourself.